### PR TITLE
make WoWUnit optional

### DIFF
--- a/sets/tests.lua
+++ b/sets/tests.lua
@@ -1,22 +1,24 @@
-﻿local Sets = Combuctor:GetModule('Sets')
-local Exists, None = WoWUnit.Exists, WoWUnit.IsFalse
-local Tests = WoWUnit('Combuctor.Sets')
+if(type(WoWUnit) == "table") then
+	local Sets = Combuctor:GetModule('Sets')
+	local Exists, None = WoWUnit.Exists, WoWUnit.IsFalse
+	local Tests = WoWUnit('Combuctor.Sets')
 
-function Tests:Set()
-	Sets:Register('bacon', 'someIcon')
-	Exists(Sets:Get('bacon'))
+	function Tests:Set()
+		Sets:Register('bacon', 'someIcon')
+		Exists(Sets:Get('bacon'))
 
-	Sets:Unregister('bacon')
-	None(Sets:Get('bacon'))
-end
+		Sets:Unregister('bacon')
+		None(Sets:Get('bacon'))
+	end
 
-function Tests:Subset()
-	Sets:Register('bacon', 'someIcon')
-	Sets:RegisterSubSet('cheese', 'bacon', 'someIcon')
-	Exists(Sets:Get('cheese', 'bacon'))
+	function Tests:Subset()
+		Sets:Register('bacon', 'someIcon')
+		Sets:RegisterSubSet('cheese', 'bacon', 'someIcon')
+		Exists(Sets:Get('cheese', 'bacon'))
 
-	Sets:Unregister('cheese', 'bacon')
-	None(Sets:Get('cheese'))
+		Sets:Unregister('cheese', 'bacon')
+		None(Sets:Get('cheese'))
 
-	Sets:Unregister('bacon')
+		Sets:Unregister('bacon')
+	end
 end


### PR DESCRIPTION
In a install without WoWUnit, this file would yield a lua error.